### PR TITLE
Add RichTextBox support for notes

### DIFF
--- a/StickyNotesEdge/MainWindow.xaml.cs
+++ b/StickyNotesEdge/MainWindow.xaml.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
+using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
@@ -80,7 +81,7 @@ namespace StickyNotesEdge
                         if (container != null)
                         {
                             var noteControl = VisualTreeHelper.GetChild(container, 0) as StickyNoteControl;
-                            var textBox = noteControl?.FindName("NoteTextBox") as TextBox; // Adjust name if needed
+                            var textBox = noteControl?.FindName("NoteRichTextBox") as RichTextBox; // Adjust name if needed
                             textBox?.Focus();
                         }
                     }), DispatcherPriority.Loaded);
@@ -234,18 +235,19 @@ namespace StickyNotesEdge
                 {
                     Padding = new Thickness(20),
                     Background = new SolidColorBrush(Color.FromRgb(255, 255, 200)),
-                    Child = new TextBox
+                    Child = new RichTextBox
                     {
-                        Text = note.Text,
                         FontSize = 24,
                         Background = Brushes.Transparent,
                         BorderThickness = new Thickness(0),
                         IsReadOnly = true,
-                        TextWrapping = TextWrapping.Wrap,
                         VerticalScrollBarVisibility = ScrollBarVisibility.Auto
                     }
                 }
             };
+
+            var rtb = (RichTextBox)((Border)largeNote.Content).Child;
+            rtb.Document = Utilities.XamlToFlowDocument(note.Text);
 
             var vm = DataContext as MainViewModel;
             if (vm != null)

--- a/StickyNotesEdge/StickyNoteControl.xaml
+++ b/StickyNotesEdge/StickyNoteControl.xaml
@@ -66,18 +66,17 @@
             </StackPanel>
 
             <!-- Note Text (below buttons, fills width, with padding from Border) -->
-            <TextBox x:Name="NoteTextBox"
+            <RichTextBox x:Name="NoteRichTextBox"
                  Grid.Row="1"
-                 Text="{Binding Text, UpdateSourceTrigger=PropertyChanged}"
                  FontSize="16"
                  Background="Transparent"
                  BorderThickness="0"
-                 TextWrapping="Wrap"
                  AcceptsReturn="True"
                  VerticalAlignment="Stretch"
                  HorizontalAlignment="Stretch"
                  Padding="8,4"
-                 Margin="0,0,0,0"/>
+                 Margin="0,0,0,0"
+                 VerticalScrollBarVisibility="Auto" />
         </Grid>
     </Border>
 </UserControl>

--- a/StickyNotesEdge/StickyNoteControl.xaml.cs
+++ b/StickyNotesEdge/StickyNoteControl.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using StickyNotesEdge.Models;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Documents;
 using System.Windows.Media;
 
 namespace StickyNotesEdge
@@ -10,6 +11,24 @@ namespace StickyNotesEdge
         public StickyNoteControl()
         {
             InitializeComponent();
+            Loaded += StickyNoteControl_Loaded;
+            NoteRichTextBox.LostFocus += NoteRichTextBox_LostFocus;
+        }
+
+        private void StickyNoteControl_Loaded(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is StickyNote note)
+            {
+                NoteRichTextBox.Document = Utilities.XamlToFlowDocument(note.Text);
+            }
+        }
+
+        private void NoteRichTextBox_LostFocus(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is StickyNote note)
+            {
+                note.Text = Utilities.FlowDocumentToXaml(NoteRichTextBox.Document);
+            }
         }
     }
 }

--- a/StickyNotesEdge/Utilities.cs
+++ b/StickyNotesEdge/Utilities.cs
@@ -1,16 +1,54 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows.Documents;
+using System.Windows.Markup;
 using System.Windows.Media.Animation;
 
 namespace StickyNotesEdge
 {
     internal static class Utilities
     {
+        public static string FlowDocumentToXaml(FlowDocument document)
+        {
+            if (document == null)
+                return string.Empty;
 
+            var range = new TextRange(document.ContentStart, document.ContentEnd);
+            using var ms = new MemoryStream();
+            range.Save(ms, DataFormats.Xaml);
+            return Encoding.UTF8.GetString(ms.ToArray());
+        }
+
+        public static FlowDocument XamlToFlowDocument(string? text)
+        {
+            if (string.IsNullOrEmpty(text))
+                return new FlowDocument();
+
+            try
+            {
+                if (text.TrimStart().StartsWith("<FlowDocument"))
+                {
+                    var doc = new FlowDocument();
+                    var range = new TextRange(doc.ContentStart, doc.ContentEnd);
+                    using var ms = new MemoryStream(Encoding.UTF8.GetBytes(text));
+                    range.Load(ms, DataFormats.Xaml);
+                    return doc;
+                }
+                else
+                {
+                    return new FlowDocument(new Paragraph(new Run(text)));
+                }
+            }
+            catch
+            {
+                return new FlowDocument(new Paragraph(new Run(text ?? string.Empty)));
+            }
+        }
 
     }
 }


### PR DESCRIPTION
## Summary
- switch StickyNoteControl from `TextBox` to `RichTextBox`
- load and save FlowDocument content through new helpers
- display formatted notes in large note window
- update focus logic when adding a new note

## Testing
- `dotnet build StickyNotesEdge/StickyNotesEdge.csproj -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849b33e565c832f8f618d62795ad300